### PR TITLE
Makes qml exporting more complete

### DIFF
--- a/data/qmls/line_simple.qml
+++ b/data/qmls/line_simple.qml
@@ -1,29 +1,22 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyAlgorithm="0" version="3.4.3-Madeira" simplifyMaxScale="1" simplifyDrawingTol="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8" labelsEnabled="0" simplifyDrawingHints="1" maxScale="0" simplifyLocal="1" readOnly="0">
-  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="singleSymbol">
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0">
+      <rule key="0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="line" name="0" force_rhr="0">
-        <layer enabled="1" pass="0" class="SimpleLine" locked="0">
-          <prop v="square" k="capstyle"/>
-          <prop v="12;12" k="customdash"/>
-          <prop v="3x:0,0,0,0,0,0" k="customdash_map_unit_scale"/>
-          <prop v="Pixel" k="customdash_unit"/>
-          <prop v="0" k="draw_inside_polygon"/>
-          <prop v="round" k="joinstyle"/>
-          <prop v="255,0,255,255" k="line_color"/>
-          <prop v="solid" k="line_style"/>
-          <prop v="3" k="line_width"/>
-          <prop v="Pixel" k="line_width_unit"/>
-          <prop v="2" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Pixel" k="offset_unit"/>
-          <prop v="0" k="ring_filter"/>
-          <prop v="1" k="use_custom_dash"/>
-          <prop v="3x:0,0,0,0,0,0" k="width_map_unit_scale"/>
+      <symbol type="line" name="0">
+        <layer class="SimpleLine">
+          <prop k="line_color" v="255,0,255,255"/>
+          <prop k="offset" v="2"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="Pixel"/>
+          <prop k="joinstyle" v="round"/>
+          <prop k="capstyle" v="square"/>
+          <prop k="line_width" v="3"/>
+          <prop k="customdash" v="12;12"/>
         </layer>
       </symbol>
     </symbols>
-    <rotation/>
-    <sizescale/>
   </renderer-v2>
 </qgis>

--- a/data/qmls/point_external_graphic.qml
+++ b/data/qmls/point_external_graphic.qml
@@ -1,152 +1,20 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyAlgorithm="0" version="3.4.3-Madeira" simplifyMaxScale="1" simplifyDrawingTol="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8" labelsEnabled="0" simplifyDrawingHints="0" maxScale="0" simplifyLocal="1" readOnly="0">
-  <flags>
-    <Identifiable>1</Identifiable>
-    <Removable>1</Removable>
-    <Searchable>1</Searchable>
-  </flags>
-  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="singleSymbol">
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0">
+      <rule key="0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="marker" name="0" force_rhr="0">
-        <layer enabled="1" pass="0" class="SvgMarker" locked="0">
-          <prop v="0" k="angle"/>
-          <prop v="125,139,143,255" k="color"/>
-          <prop v="0" k="fixedAspectRatio"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="35,35,35,255" k="outline_color"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="69" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="Pixel" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option value="" type="QString" name="name"/>
-              <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
-            </Option>
-          </data_defined_properties>
+      <symbol type="marker" name="0">
+        <layer class="SvgMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="125,139,143,255"/>
+          <prop k="name" v="https://upload.wikimedia.org/wikipedia/commons/6/67/OpenLayers_logo.svg"/>
+          <prop k="size" v="69"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
         </layer>
       </symbol>
     </symbols>
-    <rotation/>
-    <sizescale/>
   </renderer-v2>
-  <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
-    <property key="variableNames"/>
-    <property key="variableValues"/>
-  </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory backgroundColor="#ffffff" sizeType="MM" barWidth="5" minimumSize="0" width="15" penWidth="0" enabled="0" opacity="1" penAlpha="255" scaleDependency="Area" diagramOrientation="Up" penColor="#000000" backgroundAlpha="255" lineSizeType="MM" minScaleDenominator="0" height="15" rotationOffset="270" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" maxScaleDenominator="1e+8" scaleBasedVisibility="0">
-      <fontProperties style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0"/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" obstacle="0" showAll="1" placement="0" linePlacementFlags="18" zIndex="0">
-    <properties>
-      <Option type="Map">
-        <Option value="" type="QString" name="name"/>
-        <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-    <activeChecks/>
-    <checkConfiguration/>
-  </geometryOptions>
-  <fieldConfiguration>
-    <field name="plot id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="geotag id">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-  </fieldConfiguration>
-  <aliases>
-    <alias index="0" field="plot id" name=""/>
-    <alias index="1" field="geotag id" name=""/>
-  </aliases>
-  <excludeAttributesWMS/>
-  <excludeAttributesWFS/>
-  <defaults>
-    <default expression="" field="plot id" applyOnUpdate="0"/>
-    <default expression="" field="geotag id" applyOnUpdate="0"/>
-  </defaults>
-  <constraints>
-    <constraint notnull_strength="0" exp_strength="0" field="plot id" constraints="0" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" field="geotag id" constraints="0" unique_strength="0"/>
-  </constraints>
-  <constraintExpressions>
-    <constraint exp="" desc="" field="plot id"/>
-    <constraint exp="" desc="" field="geotag id"/>
-  </constraintExpressions>
-  <expressionfields/>
-  <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
-  </attributeactions>
-  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
-    <columns>
-      <column hidden="0" width="-1" type="field" name="plot id"/>
-      <column hidden="0" width="-1" type="field" name="geotag id"/>
-      <column hidden="1" width="-1" type="actions"/>
-    </columns>
-  </attributetableconfig>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <editform tolerant="1"></editform>
-  <editforminit/>
-  <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath></editforminitfilepath>
-  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
-"""
-QGIS forms can have a Python function that is called when the form is
-opened.
-
-Use this function to add extra logic to your forms.
-
-Enter the name of the function in the "Python Init function"
-field.
-An example follows:
-"""
-from qgis.PyQt.QtWidgets import QWidget
-
-def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
-  <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
-  <editable>
-    <field editable="1" name="geotag id"/>
-    <field editable="1" name="plot id"/>
-  </editable>
-  <labelOnTop>
-    <field labelOnTop="0" name="geotag id"/>
-    <field labelOnTop="0" name="plot id"/>
-  </labelOnTop>
-  <widgets/>
-  <previewExpression>plot id</previewExpression>
-  <mapTip></mapTip>
-  <layerGeometryType>0</layerGeometryType>
 </qgis>

--- a/data/qmls/point_label.qml
+++ b/data/qmls/point_label.qml
@@ -1,17 +1,17 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyAlgorithm="0" version="3.4.3-Madeira" simplifyMaxScale="1" simplifyDrawingTol="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8" labelsEnabled="1" simplifyDrawingHints="0" maxScale="0" simplifyLocal="1" readOnly="0">
-  <renderer-v2 type="nullSymbol"/>
-  <labeling type="simple">
-    <settings>
-      <text-style fontCapitals="0" useSubstitutions="0" fontWeight="50" fieldName="'ID: ' || ID" fontWordSpacing="0" previewBkgrdColor="#ffffff" isExpression="0" fontStrikeout="0" fontSizeMapUnitScale="3x:0,0,0,0,0,0" textOpacity="1" textColor="0,0,0,255" fontSize="10" blendMode="0" fontUnderline="0" multilineHeight="1" namedStyle="Regular" fontFamily="Courier 10 Pitch" fontSizeUnit="Point" fontItalic="0" fontLetterSpacing="0">
-        <text-buffer bufferSize="1" bufferJoinStyle="128" bufferSizeUnits="MM" bufferColor="255,255,255,255" bufferBlendMode="0" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferDraw="0" bufferNoFill="1" bufferOpacity="1"/>
-        <background shapeType="0" shapeSizeType="0" shapeSizeY="0" shapeSizeUnit="MM" shapeOffsetUnit="MM" shapeRotation="0" shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOpacity="1" shapeDraw="0" shapeBorderColor="128,128,128,255" shapeRadiiY="0" shapeSizeX="0" shapeFillColor="255,255,255,255" shapeOffsetY="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeBorderWidth="0" shapeRadiiUnit="MM" shapeOffsetX="0" shapeRotationType="0" shapeSVGFile="" shapeJoinStyle="64" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeBlendMode="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeBorderWidthUnit="MM"/>
-        <shadow shadowRadiusAlphaOnly="0" shadowOffsetDist="1" shadowOpacity="0.7" shadowRadius="1.5" shadowBlendMode="6" shadowUnder="0" shadowColor="0,0,0,255" shadowRadiusUnit="MM" shadowScale="100" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowOffsetUnit="MM" shadowOffsetAngle="135" shadowDraw="0" shadowOffsetGlobal="1"/>
-        <substitutions/>
-      </text-style>
-      <text-format wrapChar="" formatNumbers="0" plussign="0" multilineAlign="3" autoWrapLength="0" useMaxLineLengthForAutoWrap="1" addDirectionSymbol="0" decimals="3" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" rightDirectionSymbol=">" placeDirectionSymbol="0"/>
-      <placement xOffset="13" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" distMapUnitScale="3x:0,0,0,0,0,0" centroidInside="0" offsetUnits="MM" repeatDistance="0" yOffset="37" preserveRotation="1" offsetType="0" placementFlags="10" dist="0" maxCurvedCharAngleIn="25" centroidWhole="0" distUnits="MM" maxCurvedCharAngleOut="-25" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" priority="5" placement="0" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" fitInPolygonOnly="0" repeatDistanceUnits="MM" quadOffset="4" rotationAngle="0"/>
-      <rendering drawLabels="1" mergeLines="0" fontMaxPixelSize="10000" limitNumLabels="0" maxNumLabels="2000" upsidedownLabels="0" displayAll="0" obstacleType="0" fontLimitPixelSize="0" zIndex="0" obstacle="1" labelPerPart="0" scaleVisibility="0" fontMinPixelSize="3" minFeatureSize="0" obstacleFactor="1" scaleMin="0" scaleMax="0"/>
-    </settings>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0"/>
+    <symbols/>
+  </renderer-v2>
+  <labeling type="rule-based">
+    <rules key="0">
+      <rule key="0" filter="value > 0.1">
+        <settings>
+          <text-style fontSize="10" fontLetterSpacing="0" multilineHeight="1" textColor="0,0,0,255" fontFamily="Sans Serif" fieldName="locality_name"/>
+          <placement predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" xOffset="13" yOffset="37" rotationAngle="0"/>
+        </settings>
+      </rule>
+    </rules>
   </labeling>
 </qgis>

--- a/data/qmls/point_multiple_symbols.qml
+++ b/data/qmls/point_multiple_symbols.qml
@@ -1,58 +1,38 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyMaxScale="1" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" styleCategories="AllStyleCategories" simplifyDrawingHints="0" simplifyLocal="1" simplifyAlgorithm="0" version="3.4.3-Madeira" maxScale="0" minScale="1e+8" labelsEnabled="0" readOnly="0">
-  <renderer-v2 forceraster="0" type="singleSymbol" symbollevels="0" enableorderby="0">
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0">
+      <rule key="0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
     <symbols>
-      <symbol clip_to_extent="1" force_rhr="0" type="marker" alpha="1">
-        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-          <prop v="0" k="angle"/>
-          <prop v="75,255,126,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="square" k="name"/>
-          <prop v="4,4" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Pixel" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="1" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="Pixel" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="24" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="Pixel" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol type="marker" name="0">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="75,255,126,255"/>
+          <prop k="name" v="square"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="24"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
         </layer>
-        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-          <prop v="0" k="angle"/>
-          <prop v="255,0,0,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="35,35,35,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="0" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="MM" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="4" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="MM" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option name="name" type="QString" value=""/>
-              <Option name="properties"/>
-              <Option name="type" type="QString" value="collection"/>
-            </Option>
-          </data_defined_properties>
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="255,0,0,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="4"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
         </layer>
       </symbol>
     </symbols>
-    <rotation/>
-    <sizescale/>
   </renderer-v2>
 </qgis>

--- a/data/qmls/point_rules.qml
+++ b/data/qmls/point_rules.qml
@@ -1,76 +1,55 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyDrawingHints="0" simplifyAlgorithm="0" minScale="0" simplifyMaxScale="1" simplifyDrawingTol="1" version="3.4.3-Madeira" maxScale="0" simplifyLocal="1" readOnly="0" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" labelsEnabled="0">
-  <renderer-v2 forceraster="0" type="RuleRenderer" symbollevels="0" enableorderby="0">
-    <rules key="{50555d9e-6bfb-48c2-970c-f5206e2a4ba7}">
-      <rule filter="Bildpositi = 1" scalemaxdenom="2000" scalemindenom="100" symbol="0" key="{dbf6e896-0303-4a2f-b2c5-c0fe19577c4c}"/>
-      <rule filter="Bildpositi > 1 AND Bildpositi < 3" scalemaxdenom="2000" scalemindenom="100" symbol="1" key="{9ef31362-6781-472d-9377-30906e218edb}"/>
-      <rule filter="Bildpositi = 3" scalemaxdenom="2000" scalemindenom="100" symbol="2" key="{e2eec1fb-fac9-4b10-a83d-486be5929b7a}"/>
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0">
+      <rule key="0" symbol="0" label="Bildpositi = 1" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi = 1"/>
+      <rule key="1" symbol="1" label="Bildpositi > 1 AND Bildpositi &lt; 3" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi > 1 AND Bildpositi &lt; 3"/>
+      <rule key="2" symbol="2" label="Bildpositi = 3" scalemindenom="100" scalemaxdenom="2000" filter="Bildpositi = 3"/>
     </rules>
     <symbols>
-      <symbol name="0" clip_to_extent="1" force_rhr="0" type="marker" alpha="1">
-        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-          <prop v="0" k="angle"/>
-          <prop v="75,255,126,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="square" k="name"/>
-          <prop v="4,4" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Pixel" k="offset_unit"/>
-          <prop v="0,0,0,255" k="outline_color"/>
-          <prop v="solid" k="outline_style"/>
-          <prop v="1" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="Pixel" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="24" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="Pixel" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol type="marker" name="0">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="75,255,126,255"/>
+          <prop k="name" v="square"/>
+          <prop k="outline_color" v="0,0,0,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="24"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
         </layer>
       </symbol>
-      <symbol name="1" clip_to_extent="1" force_rhr="0" type="marker" alpha="1">
-        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-          <prop v="0" k="angle"/>
-          <prop v="145,82,45,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Pixel" k="offset_unit"/>
-          <prop v="35,35,35,255" k="outline_color"/>
-          <prop v="no" k="outline_style"/>
-          <prop v="1" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="Pixel" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="12" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="Pixel" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol type="marker" name="1">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="145,82,45,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="12"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
         </layer>
       </symbol>
-      <symbol name="2" clip_to_extent="1" force_rhr="0" type="marker" alpha="1">
-        <layer enabled="1" locked="0" pass="0" class="SimpleMarker">
-          <prop v="0" k="angle"/>
-          <prop v="190,178,151,255" k="color"/>
-          <prop v="1" k="horizontal_anchor_point"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="circle" k="name"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="Pixel" k="offset_unit"/>
-          <prop v="35,35,35,255" k="outline_color"/>
-          <prop v="no" k="outline_style"/>
-          <prop v="1" k="outline_width"/>
-          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
-          <prop v="Pixel" k="outline_width_unit"/>
-          <prop v="diameter" k="scale_method"/>
-          <prop v="12" k="size"/>
-          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
-          <prop v="Pixel" k="size_unit"/>
-          <prop v="1" k="vertical_anchor_point"/>
+      <symbol type="marker" name="2">
+        <layer class="SimpleMarker">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="190,178,151,255"/>
+          <prop k="name" v="circle"/>
+          <prop k="outline_color" v="35,35,35,255"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="1"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="size" v="12"/>
+          <prop k="size_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="size_unit" v="Pixel"/>
         </layer>
       </symbol>
     </symbols>

--- a/data/qmls/point_simple.qml
+++ b/data/qmls/point_simple.qml
@@ -1,6 +1,9 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
 <qgis>
-  <renderer-v2 type="singleSymbol">
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0">
+      <rule key="0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
     <symbols>
       <symbol type="marker" name="0">
         <layer class="SimpleMarker">

--- a/data/qmls/polygon_simple.qml
+++ b/data/qmls/polygon_simple.qml
@@ -1,160 +1,23 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis simplifyAlgorithm="0" version="3.4.3-Madeira" simplifyMaxScale="1" simplifyDrawingTol="1" styleCategories="AllStyleCategories" hasScaleBasedVisibilityFlag="0" minScale="1e+8" labelsEnabled="0" simplifyDrawingHints="1" maxScale="0" simplifyLocal="1" readOnly="0">
-  <flags>
-    <Identifiable>1</Identifiable>
-    <Removable>1</Removable>
-    <Searchable>1</Searchable>
-  </flags>
-  <renderer-v2 symbollevels="0" forceraster="0" enableorderby="0" type="singleSymbol">
+<qgis>
+  <renderer-v2 type="RuleRenderer">
+    <rules key="0">
+      <rule key="0" symbol="0" label="QGIS Simple Symbol"/>
+    </rules>
     <symbols>
-      <symbol alpha="1" clip_to_extent="1" type="fill" name="0" force_rhr="0">
-        <layer enabled="1" pass="0" class="SimpleFill" locked="0">
-          <prop v="3x:0,0,0,0,0,0" k="border_width_map_unit_scale"/>
-          <prop v="75,255,126,128" k="color"/>
-          <prop v="bevel" k="joinstyle"/>
-          <prop v="0,0" k="offset"/>
-          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
-          <prop v="MM" k="offset_unit"/>
-          <prop v="255,7,11,255" k="outline_color"/>
-          <prop v="dash" k="outline_style"/>
-          <prop v="4" k="outline_width"/>
-          <prop v="Pixel" k="outline_width_unit"/>
-          <prop v="solid" k="style"/>
-          <data_defined_properties>
-            <Option type="Map">
-              <Option value="" type="QString" name="name"/>
-              <Option name="properties"/>
-              <Option value="collection" type="QString" name="type"/>
-            </Option>
-          </data_defined_properties>
+      <symbol type="fill" name="0">
+        <layer class="SimpleFill">
+          <prop k="color" v="75,255,126,128"/>
+          <prop k="offset_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="offset_unit" v="Pixel"/>
+          <prop k="outline_style" v="dash"/>
+          <prop k="outline_width" v="4"/>
+          <prop k="outline_width_map_unit_scale" v="3x:0,0,0,0,0,0"/>
+          <prop k="outline_width_unit" v="Pixel"/>
+          <prop k="customdash" v="10;2"/>
+          <prop k="outline_color" v="255,7,11,255"/>
         </layer>
       </symbol>
     </symbols>
-    <rotation/>
-    <sizescale/>
   </renderer-v2>
-  <customproperties>
-    <property key="embeddedWidgets/count" value="0"/>
-    <property key="variableNames"/>
-    <property key="variableValues"/>
-  </customproperties>
-  <blendMode>0</blendMode>
-  <featureBlendMode>0</featureBlendMode>
-  <layerOpacity>1</layerOpacity>
-  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
-    <DiagramCategory backgroundColor="#ffffff" sizeType="MM" barWidth="5" minimumSize="0" width="15" penWidth="0" enabled="0" opacity="1" penAlpha="255" scaleDependency="Area" diagramOrientation="Up" penColor="#000000" backgroundAlpha="255" lineSizeType="MM" minScaleDenominator="0" height="15" rotationOffset="270" lineSizeScale="3x:0,0,0,0,0,0" labelPlacementMethod="XHeight" sizeScale="3x:0,0,0,0,0,0" maxScaleDenominator="1e+8" scaleBasedVisibility="0">
-      <fontProperties style="" description="Sans Serif,9,-1,5,50,0,0,0,0,0"/>
-    </DiagramCategory>
-  </SingleCategoryDiagramRenderer>
-  <DiagramLayerSettings dist="0" priority="0" obstacle="0" showAll="1" placement="1" linePlacementFlags="18" zIndex="0">
-    <properties>
-      <Option type="Map">
-        <Option value="" type="QString" name="name"/>
-        <Option name="properties"/>
-        <Option value="collection" type="QString" name="type"/>
-      </Option>
-    </properties>
-  </DiagramLayerSettings>
-  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
-    <activeChecks/>
-    <checkConfiguration/>
-  </geometryOptions>
-  <fieldConfiguration>
-    <field name="WKT">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="ID">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-    <field name="SORTE">
-      <editWidget type="TextEdit">
-        <config>
-          <Option/>
-        </config>
-      </editWidget>
-    </field>
-  </fieldConfiguration>
-  <aliases>
-    <alias index="0" field="WKT" name=""/>
-    <alias index="1" field="ID" name=""/>
-    <alias index="2" field="SORTE" name=""/>
-  </aliases>
-  <excludeAttributesWMS/>
-  <excludeAttributesWFS/>
-  <defaults>
-    <default expression="" field="WKT" applyOnUpdate="0"/>
-    <default expression="" field="ID" applyOnUpdate="0"/>
-    <default expression="" field="SORTE" applyOnUpdate="0"/>
-  </defaults>
-  <constraints>
-    <constraint notnull_strength="0" exp_strength="0" field="WKT" constraints="0" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" field="ID" constraints="0" unique_strength="0"/>
-    <constraint notnull_strength="0" exp_strength="0" field="SORTE" constraints="0" unique_strength="0"/>
-  </constraints>
-  <constraintExpressions>
-    <constraint exp="" desc="" field="WKT"/>
-    <constraint exp="" desc="" field="ID"/>
-    <constraint exp="" desc="" field="SORTE"/>
-  </constraintExpressions>
-  <expressionfields/>
-  <attributeactions>
-    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
-  </attributeactions>
-  <attributetableconfig sortOrder="0" sortExpression="" actionWidgetStyle="dropDown">
-    <columns>
-      <column hidden="0" width="-1" type="field" name="WKT"/>
-      <column hidden="0" width="-1" type="field" name="ID"/>
-      <column hidden="0" width="-1" type="field" name="SORTE"/>
-      <column hidden="1" width="-1" type="actions"/>
-    </columns>
-  </attributetableconfig>
-  <conditionalstyles>
-    <rowstyles/>
-    <fieldstyles/>
-  </conditionalstyles>
-  <editform tolerant="1"></editform>
-  <editforminit/>
-  <editforminitcodesource>0</editforminitcodesource>
-  <editforminitfilepath></editforminitfilepath>
-  <editforminitcode><![CDATA[# -*- coding: utf-8 -*-
-"""
-QGIS forms can have a Python function that is called when the form is
-opened.
-
-Use this function to add extra logic to your forms.
-
-Enter the name of the function in the "Python Init function"
-field.
-An example follows:
-"""
-from qgis.PyQt.QtWidgets import QWidget
-
-def my_form_open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget, "MyLineEdit")
-]]></editforminitcode>
-  <featformsuppress>0</featformsuppress>
-  <editorlayout>generatedlayout</editorlayout>
-  <editable>
-    <field editable="1" name="ID"/>
-    <field editable="1" name="SORTE"/>
-    <field editable="1" name="WKT"/>
-  </editable>
-  <labelOnTop>
-    <field labelOnTop="0" name="ID"/>
-    <field labelOnTop="0" name="SORTE"/>
-    <field labelOnTop="0" name="WKT"/>
-  </labelOnTop>
-  <widgets/>
-  <previewExpression>ID</previewExpression>
-  <mapTip></mapTip>
-  <layerGeometryType>2</layerGeometryType>
 </qgis>

--- a/data/styles/point_label.ts
+++ b/data/styles/point_label.ts
@@ -4,12 +4,13 @@ const pointStyledLabel: Style = {
   name: 'QGIS Style',
   rules: [{
     name: 'QGIS Simple Symbol',
+    filter: ['>', 'value', 0.1],
     symbolizers: [{
       kind: 'Text',
       color: '#000000',
-      label: 'ID: {{ID}}',
+      label: '{{locality_name}}',
       lineHeight: 1,
-      font: ['Courier 10 Pitch'],
+      font: ['Sans Serif'],
       size: 10,
       offset: [13, 37]
     }]

--- a/dev-build.config.js
+++ b/dev-build.config.js
@@ -1,0 +1,27 @@
+const webpack = require("webpack");
+require("@babel/polyfill");
+
+module.exports = {
+  entry: ["./src/QGISStyleParser.ts"],
+  output: {
+    filename: "qgisStyleParser.js",
+    path: __dirname + "/browser",
+    library: "GeoStylerQGISParser"
+  },
+  resolve: {
+    // Add '.ts' and '.tsx' as resolvable extensions.
+    extensions: [".ts", ".tsx", ".js", ".json"]
+  },
+  module: {
+    rules: [
+      // All files with a '.ts' or '.tsx' extension will be handled by 'awesome-typescript-loader'.
+      {
+        test: /\.ts$/,
+        include: /src/,
+        loader: "awesome-typescript-loader"
+      },
+    ]
+  },
+  plugins: [
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build:browser": "webpack --config webpack.browser.config.js",
+    "start:dev": "webpack --mode development --config dev-build.config.js --watch",
     "build": "tsc -p tsconfig.json && npm run build:browser",
     "lint": "tslint --project tsconfig.json --config tslint.json && tsc --noEmit --project tsconfig.json",
     "prebuild": "npm run test",

--- a/src/QGISStyleParser.spec.ts
+++ b/src/QGISStyleParser.spec.ts
@@ -133,87 +133,69 @@ describe('QMLStyleParser implements StyleParser', () => {
             expect(qgisStyle).toEqual(qml.trim());
           });
       });
-      // it('can write a QML PointSymbolizer with an external graphic', async () => {
-      //   expect.assertions(2);
-      //   const qml = fs.readFileSync( './data/qmls/point_external_graphic.qml', 'utf8');
-      //   return styleParser.writeStyle(point_external_graphic)
-      //     .then((qgisStyle: string) => {
-      //       expect(qgisStyle).toBeDefined();
-      //       expect(qgisStyle).toEqual(qml);
-      //     });
-      // });
-      // it('can write a QML PointSymbolizer with multiple symbols', async () => {
-      //   expect.assertions(2);
-      //   const qml = fs.readFileSync( './data/qmls/point_multiple_symbols.qml', 'utf8');
-      //   return styleParser.writeStyle(point_multiple_symbols)
-      //     .then((qgisStyle: string) => {
-      //       expect(qgisStyle).toBeDefined();
-      //       expect(qgisStyle).toEqual(qml);
-      //     });
-      // });
+      it('can write a QML PointSymbolizer with an external graphic', async () => {
+        expect.assertions(2);
+        const qml = fs.readFileSync( './data/qmls/point_external_graphic.qml', 'utf8');
+        return styleParser.writeStyle(point_external_graphic)
+          .then((qgisStyle: string) => {
+            expect(qgisStyle).toBeDefined();
+            expect(qgisStyle).toEqual(qml);
+          });
+      });
+      it('can write a QML PointSymbolizer with multiple symbols', async () => {
+        expect.assertions(2);
+        const qml = fs.readFileSync( './data/qmls/point_multiple_symbols.qml', 'utf8');
+        return styleParser.writeStyle(point_multiple_symbols)
+          .then((qgisStyle: string) => {
+            expect(qgisStyle).toBeDefined();
+            expect(qgisStyle).toEqual(qml);
+          });
+      });
     });
-    // describe('TextSymbolizer', () => {
-    //   it('can write some basics of the QML Labeling for Points', async () => {
-    //     expect.assertions(2);
-    //     const qml = fs.readFileSync( './data/qmls/point_label.qml', 'utf8');
-    //     return styleParser.writeStyle(point_label)
-    //       .then((qgisStyle: string) => {
-    //         expect(qgisStyle).toBeDefined();
-    //         expect(qgisStyle).toEqual(qml);
-    //       });
-    //   });
-    // });
-    // describe('LineSymbolizer', () => {
-    //   it('can write a simple QML LineSymbol', async () => {
-    //     expect.assertions(2);
-    //     const qml = fs.readFileSync( './data/qmls/line_simple.qml', 'utf8');
-    //     return styleParser.writeStyle(line_simple)
-    //       .then((qgisStyle: string) => {
-    //         expect(qgisStyle).toBeDefined();
-    //         expect(qgisStyle).toEqual(qml);
-    //       });
-    //   });
-    // });
-    // describe('FillSymbolizer', () => {
-    //   it('can write a simple QML FillSymbol', async () => {
-    //     expect.assertions(2);
-    //     const qml = fs.readFileSync( './data/qmls/polygon_simple.qml', 'utf8');
-    //     return styleParser.writeStyle(polygon_simple)
-    //       .then((qgisStyle: string) => {
-    //         expect(qgisStyle).toBeDefined();
-    //         expect(qgisStyle).toEqual(qml);
-    //       });
-    //   });
-    // });
-    // describe('Filter Parsing', () => {
-    //   it('can write a rule based QML PointSymbolizer', async () => {
-    //     expect.assertions(2);
-    //     const qml = fs.readFileSync( './data/qmls/point_rules.qml', 'utf8');
-    //     return styleParser.writeStyle(point_rules)
-    //       .then((qgisStyle: string) => {
-    //         expect(qgisStyle).toBeDefined();
-    //         expect(qgisStyle).toEqual(qml);
-    //       });
-    //   });
-    //   it('can write a category based QML PointSymbolizer', async () => {
-    //     expect.assertions(2);
-    //     const qml = fs.readFileSync( './data/qmls/point_categories.qml', 'utf8');
-    //     return styleParser.writeStyle(point_categories)
-    //       .then((qgisStyle: string) => {
-    //         expect(qgisStyle).toBeDefined();
-    //         expect(qgisStyle).toEqual(qml);
-    //       });
-    //   });
-    //   it('can write a range based QML PointSymbolizer', async () => {
-    //     expect.assertions(2);
-    //     const qml = fs.readFileSync( './data/qmls/point_ranges.qml', 'utf8');
-    //     return styleParser.writeStyle(point_ranges)
-    //       .then((qgisStyle: string) => {
-    //         expect(qgisStyle).toBeDefined();
-    //         expect(qgisStyle).toEqual(qml);
-    //       });
-    //   });
-    // });
+    describe('TextSymbolizer', () => {
+      it('can write some basics of the QML Labeling for Points', async () => {
+        expect.assertions(2);
+        const qml = fs.readFileSync( './data/qmls/point_label.qml', 'utf8');
+        return styleParser.writeStyle(point_label)
+          .then((qgisStyle: string) => {
+            expect(qgisStyle).toBeDefined();
+            expect(qgisStyle).toEqual(qml);
+          });
+      });
+    });
+    describe('LineSymbolizer', () => {
+      it('can write a simple QML LineSymbol', async () => {
+        expect.assertions(2);
+        const qml = fs.readFileSync( './data/qmls/line_simple.qml', 'utf8');
+        return styleParser.writeStyle(line_simple)
+          .then((qgisStyle: string) => {
+            expect(qgisStyle).toBeDefined();
+            expect(qgisStyle).toEqual(qml);
+          });
+      });
+    });
+    describe('FillSymbolizer', () => {
+      it('can write a simple QML FillSymbol', async () => {
+        expect.assertions(2);
+        const qml = fs.readFileSync( './data/qmls/polygon_simple.qml', 'utf8');
+        return styleParser.writeStyle(polygon_simple)
+          .then((qgisStyle: string) => {
+            expect(qgisStyle).toBeDefined();
+            expect(qgisStyle).toEqual(qml);
+          });
+      });
+    });
+    describe('Filter Parsing', () => {
+      it('can write a rule based QML PointSymbolizer', async () => {
+        expect.assertions(2);
+        const qml = fs.readFileSync( './data/qmls/point_rules.qml', 'utf8');
+        return styleParser.writeStyle(point_rules)
+          .then((qgisStyle: string) => {
+            expect(qgisStyle).toBeDefined();
+            expect(qgisStyle).toEqual(qml);
+          });
+      });
+    });
   });
 
 });

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -46,7 +46,8 @@ type QmlRule = {
     scalemaxdenom?: number,
     scalemindenom?: number,
     symbol: string,
-    key: string
+    key: string,
+    label: string
   }
 };
 
@@ -72,6 +73,17 @@ type QmlRange = {
 export const outlineStyleDashArrays = {
   dot: [2, 2],
   dash: [10, 2]
+};
+
+const AnchorMap = {
+  left: 'L',
+  right: 'R',
+  top: 'T',
+  bottom: 'B',
+  'top-left': 'TL',
+  'top-right': 'TR',
+  'bottom-left': 'BL',
+  'bottom-right': 'BR'
 };
 
 /**
@@ -170,10 +182,10 @@ export class QGISStyleParser implements StyleParser {
    */
   qmlColorFromHexAndOpacity(hex?: string, opacity?: number): string | undefined {
     const colorArray = Color(hex).alpha(opacity).rgb().array();
-    const alpha = colorArray[3] === undefined ? 255
+    const alpha = colorArray[3] === undefined || isNaN(colorArray[3]) ? 255
       : colorArray[3] === 0 ? 0
-        : 255 / colorArray[3];
-    const color = `${colorArray[0]},${colorArray[1]},${colorArray[2]},${alpha}`;
+        : 255 * colorArray[3];
+    const color = `${colorArray[0]},${colorArray[1]},${colorArray[2]},${Math.round(alpha)}`;
 
     return color;
   }
@@ -227,7 +239,7 @@ export class QGISStyleParser implements StyleParser {
       qmlRules.forEach((qmlRule: QmlRule, index: number) => {
         const filter: Filter | undefined = this.getFilterFromQmlRule(qmlRule);
         const scaleDenominator: ScaleDenominator | undefined = this.getScaleDenominatorFromRule(qmlRule);
-        const name = qmlRule.$.filter;
+        const name = qmlRule.$.label || qmlRule.$.filter;
         let rule: Rule = <Rule> {
           name
         };
@@ -280,7 +292,6 @@ export class QGISStyleParser implements StyleParser {
     } else {
       const symbolizers = symbolizerMap[Object.keys(symbolizerMap)[0]] || [];
       const labels = labelMap[Object.keys(labelMap)[0]] || [];
-
       const rule: Rule = {
         name: 'QGIS Simple Symbol',
         symbolizers:  [
@@ -288,6 +299,16 @@ export class QGISStyleParser implements StyleParser {
           ...labels
         ]
       };
+
+      try {
+        const filter = this.cqlParser.read(Object.keys(labelMap)[0]);
+        if (filter) {
+          rule.filter = filter;
+        }
+      } catch (e) {
+        // in the case of made up filters
+      }
+
       rules.push(rule);
     }
 
@@ -342,6 +363,14 @@ export class QGISStyleParser implements StyleParser {
     const type = qmlLabeling.$.type;
     const labelMap: LabelMap = {};
 
+    if (type === 'rule-based') {
+      const rules = _get(qmlLabeling, 'rules[0].rule');
+      rules.forEach((rule: QmlRule, index: number) => {
+        const settings = _get(rule, 'settings[0]');
+        const textSymbolizer = this.getTextSymbolizerFromLabelSettings(settings);
+        labelMap[rule.$.filter || index] = [textSymbolizer];
+      });
+    }
     if (type === 'simple') {
       const settings = _get(qmlLabeling, 'settings[0]');
       const textSymbolizer = this.getTextSymbolizerFromLabelSettings(settings);
@@ -634,6 +663,7 @@ export class QGISStyleParser implements StyleParser {
       try {
         const builder = new Builder();
         const qmlObject = this.geoStylerStyleToQmlObject(geoStylerStyle);
+        this.convertTextSymbolizers(qmlObject, geoStylerStyle);
         const qmlString = builder
           .buildObject(qmlObject)
           .replace(
@@ -649,10 +679,49 @@ export class QGISStyleParser implements StyleParser {
 
   /**
    *
+   * @param filter
+   */
+  getQmlFilterFromFilter(filter: Filter): string | undefined {
+    return this.cqlParser.write(filter);
+  }
+
+  /**
+   *
+   */
+  getQmlRuleFromRule(rule: Rule, index: number) {
+    const filter = rule.filter;
+    const qmlRule: any = {
+      $: {
+        key: `${index}`,
+        symbol: `${index}`,
+        label: rule.name
+      }
+    };
+    if (rule.scaleDenominator) {
+      qmlRule.$.scalemindenom = rule.scaleDenominator.min;
+      qmlRule.$.scalemaxdenom = rule.scaleDenominator.max;
+    }
+    if (filter) {
+      const cqlFilter = this.getQmlFilterFromFilter(filter);
+      if (cqlFilter) {
+        qmlRule.$.filter = this.getQmlFilterFromFilter(filter);
+      }
+    }
+    return qmlRule;
+  }
+
+  /**
+   *
    * @param geostylerStyle
    */
-  getQmlSymbolsFromStyle(geostylerStyle: Style): any[] {
-    return geostylerStyle.rules.map(this.getQmlSymbolFromRule.bind(this));
+  getQmlSymbolsFromStyle(geostylerStyle: Style, rules: any[]): any[] {
+    return geostylerStyle.rules.map((rule, index) => {
+      const symbol = this.getQmlSymbolFromRule(rule, index);
+      if (symbol) {
+        rules.push(this.getQmlRuleFromRule(rule, index));
+      }
+      return symbol;
+    }).filter(s => s);
   }
 
   /**
@@ -661,13 +730,67 @@ export class QGISStyleParser implements StyleParser {
    */
   getQmlSymbolFromRule(rule: Rule, index: number): any {
     const layer = this.getQmlLayersFromRule(rule);
-    let type = 'marker';
-    return {
+    let type;
+    switch (rule.symbolizers[0].kind) {
+      case 'Line':
+        type = 'line';
+        break;
+      case 'Fill':
+        type = 'fill';
+        break;
+      default:
+        type = 'marker';
+    }
+    return layer && layer[0] ? {
       $: {
         type,
         name: index.toString()
       },
       layer
+    } : undefined;
+  }
+
+  /**
+   *
+   */
+  getQmlLineSymbolFromSymbolizer(symbolizer: LineSymbolizer): any {
+    const qmlProps = {
+      line_color: this.qmlColorFromHexAndOpacity(symbolizer.color, symbolizer.opacity),
+      offset: symbolizer.offset,
+      offset_map_unit_scale: '3x:0,0,0,0,0,0',
+      offset_unit: 'Pixel',
+      joinstyle: symbolizer.join,
+      capstyle: symbolizer.cap,
+      line_width: symbolizer.width,
+      customdash: symbolizer.dasharray ? symbolizer.dasharray.join(';') : null
+    };
+
+    return {
+      $: {
+        class: 'SimpleLine'
+      },
+      prop: this.propsObjectToQmlSymbolProps(qmlProps)
+    };
+  }
+
+  getQmlFillSymbolFromSymbolizer(symbolizer: FillSymbolizer): any {
+    const qmlProps = {
+      color: this.qmlColorFromHexAndOpacity(symbolizer.color, symbolizer.opacity),
+      offset_map_unit_scale: '3x:0,0,0,0,0,0',
+      offset_unit: 'Pixel',
+      outline_style: symbolizer.outlineDasharray ? 'dash' : 'solid',
+      outline_width: symbolizer.outlineWidth || 0,
+      outline_width_map_unit_scale: '3x:0,0,0,0,0,0',
+      outline_width_unit: 'Pixel',
+      customdash: symbolizer.outlineDasharray ? symbolizer.outlineDasharray.join(';') : undefined,
+      outline_color: this.qmlColorFromHexAndOpacity(symbolizer.outlineColor, 1)
+    };
+
+    return {
+      $: {
+        class: 'SimpleFill'
+      },
+      prop: this.propsObjectToQmlSymbolProps(qmlProps)
     };
   }
 
@@ -676,7 +799,8 @@ export class QGISStyleParser implements StyleParser {
    * @param rule
    */
   getQmlLayersFromRule(rule: Rule): any {
-    return rule.symbolizers.map(this.getQmlLayerFromSymbolizer.bind(this));
+    const symbolizers = rule.symbolizers.map(this.getQmlLayerFromSymbolizer.bind(this));
+    return symbolizers.length ? symbolizers : undefined;
   }
 
   /**
@@ -685,15 +809,15 @@ export class QGISStyleParser implements StyleParser {
    */
   getQmlLayerFromSymbolizer(symbolizer: Symbolizer): any {
     switch (symbolizer.kind) {
-      // case 'Fill':
-      //   clazz = 'SimpleFill';
-      //   break;
-      // case 'Icon':
-      //   clazz = 'SvgMarker';
-      //   break;
-      // case 'Line':
-      //   clazz = 'SimpleLine';
-      //   break;
+      case 'Fill':
+        return this.getQmlFillSymbolFromSymbolizer(symbolizer as FillSymbolizer);
+        break;
+      case 'Icon':
+        return this.getQmlMarkSymbolFromIconSymbolizer(symbolizer as IconSymbolizer);
+        break;
+      case 'Line':
+        return this.getQmlLineSymbolFromSymbolizer(symbolizer as LineSymbolizer);
+        break;
       case 'Mark':
         return this.getQmlMarkSymbolFromSymbolizer(symbolizer as MarkSymbolizer);
       default:
@@ -701,17 +825,35 @@ export class QGISStyleParser implements StyleParser {
     }
   }
 
+  getQmlMarkSymbolFromIconSymbolizer(symbolizer: IconSymbolizer): any {
+    const qmlProps = {
+      angle: symbolizer.rotate || 0,
+      color: this.qmlColorFromHexAndOpacity(symbolizer.color, symbolizer.opacity),
+      name: symbolizer.image,
+      size: symbolizer.size,
+      size_map_unit_scale: '3x:0,0,0,0,0,0',
+      size_unit: 'Pixel'
+    };
+
+    return {
+      $: {
+        class: 'SvgMarker'
+      },
+      prop: this.propsObjectToQmlSymbolProps(qmlProps)
+    };
+  }
+
   /**
    *
    */
   getQmlMarkSymbolFromSymbolizer(symbolizer: MarkSymbolizer): any {
     const qmlProps = {
-      angle: symbolizer.rotate,
+      angle: symbolizer.rotate || 0,
       color: this.qmlColorFromHexAndOpacity(symbolizer.color, symbolizer.opacity),
       name: symbolizer.wellKnownName.toLowerCase(),
       outline_color: this.qmlColorFromHexAndOpacity(symbolizer.strokeColor, symbolizer.strokeOpacity),
       outline_style: 'solid',
-      outline_width: symbolizer.strokeWidth,
+      outline_width: symbolizer.strokeWidth || 0,
       outline_width_map_unit_scale: '3x:0,0,0,0,0,0',
       outline_width_unit: 'Pixel',
       size: symbolizer.radius ? symbolizer.radius * 2 : undefined,
@@ -740,7 +882,7 @@ export class QGISStyleParser implements StyleParser {
           v
         }
       };
-    });
+    }).filter(s => s.$.v !== undefined);
   }
 
   /**
@@ -750,8 +892,9 @@ export class QGISStyleParser implements StyleParser {
    * @return {object} The object representation of a QML Style (readable with xml2js)
    */
   geoStylerStyleToQmlObject(geoStylerStyle: Style): any {
-    const type: string = 'singleSymbol'; // TODO determine by geostylerStyle
-    const symbols: any[] = this.getQmlSymbolsFromStyle(geoStylerStyle);
+    const type: string = 'RuleRenderer';
+    const rules: any[] = [];
+    const symbols: any[] = this.getQmlSymbolsFromStyle(geoStylerStyle, rules);
     return {
       qgis: {
         $: {},
@@ -759,12 +902,99 @@ export class QGISStyleParser implements StyleParser {
           $: {
             type
           },
+          rules: [{
+            $: {
+              key: '0'
+            },
+            rule: rules
+          }],
           symbols: [{
             symbol: symbols
           }]
         }]
       }
     };
+  }
+
+  convertTextSymbolizerRule(qmlRuleList: any[], rule: Rule) {
+    let textSymbolizer: TextSymbolizer;
+    rule.symbolizers.forEach(symbolizer => {
+      if (symbolizer.kind === 'Text') {
+        textSymbolizer = symbolizer as TextSymbolizer;
+        const textStyleAttributes: any = {
+          fontSize: textSymbolizer.size || 12,
+          fontLetterSpacing: textSymbolizer.letterSpacing || 0,
+          multilineHeight: textSymbolizer.lineHeight || 1,
+          textColor: textSymbolizer.color ? this.qmlColorFromHexAndOpacity(textSymbolizer.color, 1) : '0,0,0,255'
+        };
+        if (textSymbolizer.font) {
+          textStyleAttributes.fontFamily = textSymbolizer.font[0];
+        }
+        if (textSymbolizer.label) {
+          textStyleAttributes.fieldName = textSymbolizer.label.replace('{{', '').replace('}}', '');
+        }
+        const textRule: any = {
+          $: {
+            key: `${qmlRuleList.length}`
+          },
+          settings: [{
+            'text-style': [{
+              $: textStyleAttributes
+            }],
+            placement: [{
+              $: {
+                predefinedPositionOrder: textSymbolizer.anchor ? AnchorMap[textSymbolizer.anchor] :
+                  'TR,TL,BR,BL,R,L,TSR,BSR',
+                xOffset: textSymbolizer.offset ? `${textSymbolizer.offset[0]}` : `0`,
+                yOffset: textSymbolizer.offset ? `${textSymbolizer.offset[1]}` : `0`,
+                rotationAngle: textSymbolizer.rotate ? textSymbolizer.rotate : `0`
+              }
+            }]
+          }]
+        };
+
+        if (textSymbolizer.haloColor) {
+          textRule.settings['text-buffer'] = [{
+            $: {
+              bufferSize: textSymbolizer.haloWidth || `0`,
+              bufferColor: this.qmlColorFromHexAndOpacity(textSymbolizer.haloColor, 1)
+            }
+          }];
+        }
+
+        if (rule.filter) {
+          textRule.$.filter = this.cqlParser.write(rule.filter);
+        }
+
+        qmlRuleList.push(textRule);
+      }
+    });
+  }
+
+  convertTextSymbolizers(qmlObject: any, geoStylerStyle: Style): any {
+    const textSymbolizerRules: Rule[] = [];
+    geoStylerStyle.rules.forEach(rule => {
+      rule.symbolizers.forEach(symbolizer => {
+        if (symbolizer.kind === 'Text' && !textSymbolizerRules.includes(rule)) {
+          textSymbolizerRules.push(rule);
+        }
+      });
+    });
+    if (textSymbolizerRules.length > 0) {
+      qmlObject.qgis.labeling = [{
+        $: {
+          type: 'rule-based'
+        },
+        rules: [{
+          $: {
+            key: '0'
+          },
+          rule: []
+        }]
+      }];
+      textSymbolizerRules.forEach(rule =>
+        this.convertTextSymbolizerRule(qmlObject.qgis.labeling[0].rules[0].rule, rule));
+    }
   }
 
 }

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -811,13 +811,10 @@ export class QGISStyleParser implements StyleParser {
     switch (symbolizer.kind) {
       case 'Fill':
         return this.getQmlFillSymbolFromSymbolizer(symbolizer as FillSymbolizer);
-        break;
       case 'Icon':
         return this.getQmlMarkSymbolFromIconSymbolizer(symbolizer as IconSymbolizer);
-        break;
       case 'Line':
         return this.getQmlLineSymbolFromSymbolizer(symbolizer as LineSymbolizer);
-        break;
       case 'Mark':
         return this.getQmlMarkSymbolFromSymbolizer(symbolizer as MarkSymbolizer);
       default:

--- a/src/QGISStyleParser.ts
+++ b/src/QGISStyleParser.ts
@@ -921,7 +921,7 @@ export class QGISStyleParser implements StyleParser {
         const textStyleAttributes: any = {
           fontSize: textSymbolizer.size || 12,
           fontLetterSpacing: textSymbolizer.letterSpacing || 0,
-          multilineHeight: textSymbolizer.lineHeight || 1,
+          multilineHeight: textSymbolizer.lineHeight !== undefined ? textSymbolizer.lineHeight : 1,
           textColor: textSymbolizer.color ? this.qmlColorFromHexAndOpacity(textSymbolizer.color, 1) : '0,0,0,255'
         };
         if (textSymbolizer.font) {


### PR DESCRIPTION
This adds a couple of features for the QML exporter, in particular:

* support for parsing/exporting rule based styles
* support for exporting line, polygon and label styles
* support for exporting rule based labeling

There's still a whole lot not supported both in reading and writing, but that's to be expected given the advanced styling/labeling options of qgis.

@KaiVolland Please review.